### PR TITLE
Add multithreading to server

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "description": "Simple web app using Apache ECharts to visualize Prometheus or ClickHouse data",
   "scripts": {
-    "start": "node server.js",
+    "start": "node server.cluster.js",
+    "start:single": "node server.js",
     "dev": "nodemon --watch server.js --watch public server.js"
   },
   "dependencies": {

--- a/server.cluster.js
+++ b/server.cluster.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const cluster = require("cluster");
+const os = require("os");
+
+const isPrimary = cluster.isPrimary !== undefined ? cluster.isPrimary : cluster.isMaster;
+const numWorkers = Number(process.env.WEB_CONCURRENCY) || os.cpus().length;
+
+if (isPrimary) {
+  const shuttingDown = { value: false };
+  console.log(`Primary ${process.pid} starting ${numWorkers} workers`);
+
+  for (let i = 0; i < numWorkers; i += 1) {
+    cluster.fork();
+  }
+
+  cluster.on("exit", (worker, code, signal) => {
+    console.warn(`Worker ${worker.process.pid} exited (code=${code}, signal=${signal})`);
+    if (!shuttingDown.value) {
+      console.log("Spawning a new worker...");
+      cluster.fork();
+    }
+  });
+
+  const graceful = (signal) => {
+    console.log(`Primary received ${signal}. Stopping workers...`);
+    shuttingDown.value = true;
+    for (const id in cluster.workers) {
+      const w = cluster.workers[id];
+      if (w && w.isConnected()) {
+        w.process.kill("SIGTERM");
+      }
+    }
+    // Give workers a moment to exit cleanly
+    setTimeout(() => process.exit(0), 500);
+  };
+
+  process.on("SIGINT", () => graceful("SIGINT"));
+  process.on("SIGTERM", () => graceful("SIGTERM"));
+} else {
+  require("./server");
+}

--- a/server.js
+++ b/server.js
@@ -135,6 +135,19 @@ app.post('/api/clickhouse/query', async (req, res) => {
 // Static frontend
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.listen(PORT, () => {
-  console.log(`Server running on http://localhost:${PORT}`);
+const server = app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT} (pid=${process.pid})`);
 });
+
+function shutdown(signal) {
+  console.log(`Worker ${process.pid} received ${signal}. Closing server...`);
+  server.close(() => {
+    console.log(`Worker ${process.pid} closed. Exiting.`);
+    process.exit(0);
+  });
+  // Force exit if not closed in time
+  setTimeout(() => process.exit(1), 5000).unref();
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));


### PR DESCRIPTION
Add multithreading to the server for improved concurrency and resilience.

This is implemented by introducing `server.cluster.js` which forks workers based on CPU count or `WEB_CONCURRENCY` and handles worker respawning. Graceful shutdown has been added to `server.js` for clean worker termination. The default `npm start` now runs the clustered version, while `npm run start:single` runs the original single-process server.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d2e099e-74ba-49cc-96dc-06c010944094">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d2e099e-74ba-49cc-96dc-06c010944094">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

